### PR TITLE
chore: use CODEOWNERS instead of reviewers in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: "weekly"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    reviewers:
-      - "ymtdzzz"
     groups:
       dependencies:
         patterns:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ymtdzzz


### PR DESCRIPTION
fixes #17 